### PR TITLE
Fix electric bus charger indexing bug

### DIFF
--- a/2025.08/2weeks/0805/16192.electric_bus.py
+++ b/2025.08/2weeks/0805/16192.electric_bus.py
@@ -45,7 +45,8 @@ for t in range(1, T + 1):
     # N = 버스 도착 마지막 번호
     # M = 충전기 개수
     charger_list = list(map(int, input().split()))
-    stop = [0] * N  # 정류장 리스트
+    # 정류장 번호는 0번부터 N번까지 존재하므로 N+1 크기로 생성한다.
+    stop = [0] * (N + 1)  # 정류장 리스트
     # stop[1] == 1 1번엔 없다
     # stop[2] == 2 2번엔 없다
     for i in charger_list:


### PR DESCRIPTION
## Summary
- prevent IndexError in Electric Bus solution by allocating stop list for 0..N

## Testing
- `python -m py_compile 2025.08/2weeks/0805/16192.electric_bus.py`
- `python 2025.08/2weeks/0805/16192.electric_bus.py << 'EOF'
1
3 10 4
1 3 7 10
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68a1c6cf7094832cb699c53eddc874dc